### PR TITLE
When navigating using AJAX, push state to browser history

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,9 +288,9 @@ GEM
       declarative
       pipetree (>= 0.1.1, < 0.2.0)
       uber
-    turbolinks (5.1.1)
-      turbolinks-source (~> 5.1)
-    turbolinks-source (5.1.0)
+    turbolinks (5.2.0)
+      turbolinks-source (~> 5.2)
+    turbolinks-source (5.2.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uber (0.1.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,5 +11,4 @@
 // about supported directives.
 //
 //= require rails-ujs
-//= require turbolinks
 //= require_tree .

--- a/app/controllers/standard/sections_controller.rb
+++ b/app/controllers/standard/sections_controller.rb
@@ -33,10 +33,5 @@ module Standard
 	  end
 	  helper_method :current_section
 
-	  def initial_load?
-	  	/\/parts\/\d+\/sections\/\d+/.match(request.referer).nil?
-	  end
-	  helper_method :initial_load?
-
 	end
 end

--- a/app/helpers/nav_helper.rb
+++ b/app/helpers/nav_helper.rb
@@ -1,7 +1,0 @@
-module NavHelper
-
-	def open_menu_section?(part)
-		current_section && current_section.part == part && !initial_load?
-	end
-
-end

--- a/app/javascript/animated_nav.js
+++ b/app/javascript/animated_nav.js
@@ -57,7 +57,7 @@ class AnimatedNav {
         method: "GET",
         url: href
       }).done((response) => {
-        history.pushState({forceReload: true}, null, href);
+        history.pushState({forceLoad: true}, null, href);
 
         $('.active').removeClass('active')
         currentLink.addClass('active')
@@ -72,16 +72,13 @@ class AnimatedNav {
   }
 }
 
-$(document).ready(()=>{
-  $(window).on('popstate', ()=>{
-    // if we have gone back/forward to a page put in the history by pushState, 
-    // force the browser to load the page, because the
-    // it has no cached version of the page to display
-    const href = window.location.pathname    
-    if (history.state.forceReload) {
-      window.location.assign(href)
-    }
-  })
+$(window).on('popstate', ()=>{
+  // if we have gone back/forward to a page put in the history by pushState, 
+  // force the browser to load the page, because it has no cached version of the page to display
+  const href = window.location.pathname    
+  if (history.state.forceLoad) {
+    window.location.assign(href)
+  }
 })
 
 $(document).on('turbolinks:load', () => {

--- a/app/javascript/animated_nav.js
+++ b/app/javascript/animated_nav.js
@@ -32,19 +32,19 @@ class AnimatedNav {
       })
   		if (section.find(`${this.link}.active`).length > 0) {
 				section.find(`${this.link}.active`).parent().siblings('.arrow').addClass('active')
-			}
-  	}
-  	
-  	$('body').on('click', this.sectionHeader, (event) => {
-  		const section = $(event.currentTarget).parent()
-  		
-  		if (section.hasClass('open')) {
-  			closeOpenSection(section)
-	  	} else {
-	  		closeOpenSection($('.menu__section.open').first())
-	  		openClosedSection(section)
-	  	}
-  	})
+      }
+    }
+    
+    $('body').on('click', this.sectionHeader, (event) => {
+      const section = $(event.currentTarget).parent()
+      
+      if (section.hasClass('open')) {
+        closeOpenSection(section)
+      } else {
+        closeOpenSection($('.menu__section.open').first())
+        openClosedSection(section)
+      }
+    })
 
     $('body').on('click', this.link, (event) => {
       event.preventDefault()
@@ -52,10 +52,13 @@ class AnimatedNav {
 
       const currentLink = $(event.currentTarget)
       const href = currentLink.parent().attr('href')
+
       $.ajax({
         method: "GET",
         url: href
       }).done((response) => {
+        history.pushState({forceReload: true}, null, href);
+
         $('.active').removeClass('active')
         currentLink.addClass('active')
         const arrow = currentLink.parent().siblings('.arrow')
@@ -65,13 +68,28 @@ class AnimatedNav {
         $('.text').html(newPage)
       });
     })
+
   }
 }
 
+$(document).ready(()=>{
+  $(window).on('popstate', ()=>{
+    // if we have gone back/forward to a page put in the history by pushState, 
+    // force the browser to load the page, because the
+    // it has no cached version of the page to display
+    const href = window.location.pathname    
+    if (history.state.forceReload) {
+      window.location.assign(href)
+    }
+  })
+})
+
 $(document).on('turbolinks:load', () => {
-  const nav = new AnimatedNav()
-  nav.setup()
-  nav.listen()
+  if ($('.js-class-standard-show-section-page').length > 0) {
+    const nav = new AnimatedNav()
+    nav.setup()
+    nav.listen()
+  }
 })
 
 

--- a/app/javascript/jquery_plugins.js
+++ b/app/javascript/jquery_plugins.js
@@ -1,7 +1,5 @@
 (function ($) {
-
 	$.fn.reverse = [].reverse;
- 
 }(jQuery));
 
 export const cascade = async (items, direction, speed, callback) => {

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -6,6 +6,8 @@
 //
 // To reference this file, add <%= javascript_pack_tag 'application' %> to the appropriate
 // layout file, like app/views/layouts/application.html.erb
+import Turbolinks from 'turbolinks'
+Turbolinks.start()
 import 'babel-polyfill'
 require("jquery-ui/ui/widgets/sortable");
 

--- a/app/views/application/_head.html.erb
+++ b/app/views/application/_head.html.erb
@@ -4,6 +4,5 @@
 <script>document.documentElement.className = document.documentElement.className.replace( 'no-js' , 'js' );</script>
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
       rel="stylesheet">
-<%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-<%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+<%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
 <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>

--- a/app/views/application/_navigation.html.erb
+++ b/app/views/application/_navigation.html.erb
@@ -1,6 +1,6 @@
 <ul class='menu'>
   <% @parts.each do |part| %>
-  	<div class="menu__section <%= 'open' if open_menu_section?(part) %>">
+  	<div class="menu__section">
 	    <li class='menu__section-header' data-id='<%= part.id %>'><%= part.title %></li>
 	    <% part.sections.by_position.each do |section| %>
 	    	<div class="menu__link">

--- a/app/views/standard/sections/show.html.erb
+++ b/app/views/standard/sections/show.html.erb
@@ -1,4 +1,4 @@
-<div class='page' />
+<div class='js-class-standard-show-section-page page' />
 
 <div class='text'>
 	<% if text %>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "@rails/webpacker": "3.5",
     "jquery": "^3.3.1",
-    "jquery-ui": "^1.12.1"
+    "jquery-ui": "^1.12.1",
+    "turbolinks": "^5.2.0"
   },
   "devDependencies": {
     "webpack-dev-server": "2.11.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6307,6 +6307,11 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+turbolinks@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/turbolinks/-/turbolinks-5.2.0.tgz#e6877a55ea5c1cb3bb225f0a4ae303d6d32ff77c"
+  integrity sha512-pMiez3tyBo6uRHFNNZoYMmrES/IaGgMhQQM+VFF36keryjb5ms0XkVpmKHkfW/4Vy96qiGW3K9bz0tF5sK9bBw==
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"


### PR DESCRIPTION
This means you can use browser back/forward buttons.

To get those buttons to work, we force the browser to load the page fully if back/forward has got us to a page that was put in the browser history by pushState. 

Drawbacks are that:
- this causes a full page load, and 
- it doesn't set the referer properly, so coming back from another section of the site doesn't animate the nav as it should. To deal with this, I have stopped initialising the page with a nav section open anyway - it always animates in on initial load. Then the ajax nav takes over and the nav section stays open.